### PR TITLE
Add benchmark suite for LSM vs B-tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,22 @@ persistence via gob files. A small storage engine wrapping the B-tree is
 provided to offer `Put`, `Get` and `Delete` operations similar to the
 LSM tree example.
 
+
+## Benchmarks
+
+A small benchmark under `benchmark/` compares read and write performance
+between the LSM tree and B-tree using the same randomly generated data set.
+Run it with:
+
+```bash
+go test -bench . -benchmem ./benchmark
+```
+
+Results on a sample run:
+
+```
+BenchmarkWriteLSM-3     121      8770492 ns/op      3105421 B/op    40414 allocs/op
+BenchmarkWriteBTree-3     1  28951579208 ns/op  13945980560 B/op  50513455 allocs/op
+BenchmarkReadLSM-3        1  1012496209 ns/op    561200192 B/op  12894572 allocs/op
+BenchmarkReadBTree-3    668    1665341 ns/op             0 B/op        0 allocs/op
+```

--- a/benchmark/benchmark_test.go
+++ b/benchmark/benchmark_test.go
@@ -1,0 +1,131 @@
+package benchmark
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
+	"btree"
+	"lsm/lsmtree"
+)
+
+type kv struct {
+	k string
+	v string
+}
+
+func genData(n int) []kv {
+	r := rand.New(rand.NewSource(1))
+	letters := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	data := make([]kv, n)
+	for i := 0; i < n; i++ {
+		b := make([]rune, 16)
+		for j := range b {
+			b[j] = letters[r.Intn(len(letters))]
+		}
+		key := fmt.Sprintf("key%06d_%s", i, string(b))
+		val := fmt.Sprintf("val_%s", string(b))
+		data[i] = kv{k: key, v: val}
+	}
+	return data
+}
+
+func BenchmarkWriteLSM(b *testing.B) {
+	data := genData(10000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		os.RemoveAll("bench_lsm")
+		tree, err := lsmtree.New("bench_lsm", 1000)
+		if err != nil {
+			b.Fatalf("new lsm: %v", err)
+		}
+		for _, kv := range data {
+			if err := tree.Put(kv.k, kv.v); err != nil {
+				b.Fatalf("put: %v", err)
+			}
+		}
+	}
+}
+
+func BenchmarkWriteBTree(b *testing.B) {
+	data := genData(10000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		os.Remove("btree.gob")
+		eng, err := btree.Open("btree.gob", 3)
+		if err != nil {
+			b.Fatalf("open: %v", err)
+		}
+		for _, kv := range data {
+			if err := eng.Put(kv.k, kv.v); err != nil {
+				b.Fatalf("put: %v", err)
+			}
+		}
+	}
+}
+
+func prepLSM(data []kv) (*lsmtree.LSMTree, error) {
+	os.RemoveAll("bench_lsm")
+	t, err := lsmtree.New("bench_lsm", 1000)
+	if err != nil {
+		return nil, err
+	}
+	for _, kv := range data {
+		if err := t.Put(kv.k, kv.v); err != nil {
+			return nil, err
+		}
+	}
+	return t, nil
+}
+
+func prepBTree(data []kv) (*btree.Engine, error) {
+	os.Remove("btree.gob")
+	e, err := btree.Open("btree.gob", 3)
+	if err != nil {
+		return nil, err
+	}
+	for _, kv := range data {
+		if err := e.Put(kv.k, kv.v); err != nil {
+			return nil, err
+		}
+	}
+	return e, nil
+}
+
+func BenchmarkReadLSM(b *testing.B) {
+	data := genData(10000)
+	tree, err := prepLSM(data)
+	if err != nil {
+		b.Fatalf("prep lsm: %v", err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, kv := range data {
+			if _, ok, err := tree.Get(kv.k); err != nil || !ok {
+				b.Fatalf("get: %v %v", err, ok)
+			}
+		}
+	}
+}
+
+func BenchmarkReadBTree(b *testing.B) {
+	data := genData(10000)
+	eng, err := prepBTree(data)
+	if err != nil {
+		b.Fatalf("prep btree: %v", err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, kv := range data {
+			if _, ok, err := eng.Get(kv.k); err != nil || !ok {
+				b.Fatalf("get: %v %v", err, ok)
+			}
+		}
+	}
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}

--- a/benchmark/go.mod
+++ b/benchmark/go.mod
@@ -1,0 +1,11 @@
+module benchmark
+
+go 1.23.8
+
+require (
+    lsm v0.0.0
+    btree v0.0.0
+)
+
+replace lsm => ../lsm
+replace btree => ../btree


### PR DESCRIPTION
## Summary
- add benchmark module comparing write/read speed of LSM tree and B-tree
- document benchmark results in README

## Testing
- `go test ./btree`
- `go test ./lsm/...`
- `go test -bench . -benchmem` in `benchmark`

------
https://chatgpt.com/codex/tasks/task_e_685a56b0bfc0832691eababa5f46fc75