### PR TITLE
Add go-api Dockerfile and compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.8'
+services:
+  go-api:
+    build:
+      context: .
+      dockerfile: services/go-api/Dockerfile
+    ports:
+      - "9464:9464"
+      - "8080:8080"
+    environment:
+      OTEL_SERVICE_NAME: go-api
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
+      OTEL_EXPORTER_PROMETHEUS_PORT: 9464

--- a/services/go-api/Dockerfile
+++ b/services/go-api/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.23 AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /go-api
+
+FROM gcr.io/distroless/base-debian12
+COPY --from=build /go-api /go-api
+EXPOSE 8080
+ENTRYPOINT ["/go-api"]


### PR DESCRIPTION
## Summary
- add Dockerfile for building `services/go-api`
- add docker-compose file to run the API

## Testing
- `go test ./btree`
- `go test ./lsm/...`
- `go test ./services/go-api/...`


------
https://chatgpt.com/codex/tasks/task_e_685ba03178a48326aa9077fcb91c9028