### PR TITLE
Add ClickHouse and OTel services

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,13 @@ go run ./services/go-api
 
 The service exposes a `/metrics` endpoint compatible with Prometheus. Histogram
 buckets are configured so you can query p50, p90, p95 and p99 latencies.
+
+### Docker Compose
+
+All services can be started locally using `nerdctl`:
+
+```bash
+nerdctl compose up
+```
+
+This brings up the Go API, ClickHouse and the OpenTelemetry Collector configured in `docker-compose.yml`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,38 @@ services:
     environment:
       OTEL_SERVICE_NAME: go-api
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
-      OTEL_EXPORTER_PROMETHEUS_PORT: 9464
+      OTEL_EXPORTER_PROMETHEUS_PORT: "9464"
+      CLICKHOUSE_ENDPOINT: http://clickhouse:8123
+      CLICKHOUSE_DATABASE: otel
+      CLICKHOUSE_USERNAME: default
+      CLICKHOUSE_PASSWORD: secret
+  clickhouse:
+    image: clickhouse/clickhouse-server:23.8
+    ports:
+      - "8123:8123"
+      - "9000:9000"
+    environment:
+      CLICKHOUSE_DB: otel
+      CLICKHOUSE_USER: default
+      CLICKHOUSE_PASSWORD: secret
+    volumes:
+      - clickhouse-data:/var/lib/clickhouse
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.93.0
+    command: ["--config=/etc/otelcol/config.yaml"]
+    volumes:
+      - ./services/otel-collector/config.yaml:/etc/otelcol/config.yaml:ro
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+      - "8888:8888"
+    environment:
+      CLICKHOUSE_ENDPOINT: http://clickhouse:8123
+      CLICKHOUSE_DATABASE: otel
+      CLICKHOUSE_USERNAME: default
+      CLICKHOUSE_PASSWORD: secret
+volumes:
+  clickhouse-data:
+networks:
+  default:
+    driver: bridge

--- a/services/otel-collector/config.yaml
+++ b/services/otel-collector/config.yaml
@@ -1,0 +1,19 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+processors:
+  batch:
+exporters:
+  clickhouse:
+    endpoint: ${CLICKHOUSE_ENDPOINT}
+    database: ${CLICKHOUSE_DATABASE}
+    username: ${CLICKHOUSE_USERNAME}
+    password: ${CLICKHOUSE_PASSWORD}
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [clickhouse]


### PR DESCRIPTION
## Summary
- add ClickHouse and OTel Collector containers to docker-compose
- configure OTEL exporter in Go API and add collector config
- mention `nerdctl compose up` usage in README

## Testing
- `go test ./...` in lsm module
- `go test ./...` in btree module
- `go test ./...` in services/go-api

------
https://chatgpt.com/codex/tasks/task_e_685bb97cc3808326b00e5afc646009d2