### PR TITLE
Expose Prometheus port through env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ configure tracing via environment variables:
 * `OTEL_SERVICE_VERSION` – optional version tag.
 * `OTEL_SAMPLER_RATIO` – sampling ratio between `0` and `1`.
 * `OTEL_CUSTOM_TAGS` – comma separated custom span tags (`key=value`).
+* `OTEL_EXPORTER_PROMETHEUS_PORT` – port to expose Prometheus metrics (defaults to `9464`).
 
 Example:
 
@@ -77,6 +78,7 @@ OTEL_SERVICE_NAME=go-api \
 OTEL_SERVICE_VERSION=1.0.0 \
 OTEL_SAMPLER_RATIO=1 \
 OTEL_CUSTOM_TAGS=env=dev,team=infra \
+OTEL_EXPORTER_PROMETHEUS_PORT=9464 \
 go run ./services/go-api
 ```
 
@@ -92,3 +94,4 @@ nerdctl compose up
 ```
 
 This brings up the Go API, ClickHouse and the OpenTelemetry Collector configured in `docker-compose.yml`.
+The Go API exposes metrics on the port defined by `OTEL_EXPORTER_PROMETHEUS_PORT` (mapped to `9464` by default).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
       OTEL_SERVICE_NAME: go-api
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
+      # Port for the standalone Prometheus metrics server
       OTEL_EXPORTER_PROMETHEUS_PORT: "9464"
       CLICKHOUSE_ENDPOINT: http://clickhouse:8123
       CLICKHOUSE_DATABASE: otel

--- a/services/go-api/main.go
+++ b/services/go-api/main.go
@@ -95,6 +95,16 @@ func main() {
 	r.Use(MetricsMiddleware())
 	r.Use(LoggingMiddleware())
 
+	metricsPort := os.Getenv("OTEL_EXPORTER_PROMETHEUS_PORT")
+	if metricsPort == "" {
+		metricsPort = "9464"
+	}
+	go func() {
+		if err := http.ListenAndServe(":"+metricsPort, promhttp.Handler()); err != nil {
+			log.Fatal().Err(err).Msg("metrics server error")
+		}
+	}()
+
 	client := http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
 
 	r.GET("/metrics", gin.WrapH(promhttp.Handler()))


### PR DESCRIPTION
## Summary
- start Prometheus server on the port from `OTEL_EXPORTER_PROMETHEUS_PORT`
- document the new variable in README and docker-compose

## Testing
- `go build ./services/go-api/...`


------
https://chatgpt.com/codex/tasks/task_e_685bc6dbc3a08326962c60a9dc5896e4